### PR TITLE
Remove unused async imports

### DIFF
--- a/ir
+++ b/ir
@@ -3,7 +3,7 @@
 """ir - Generate an XML report with metadata and features of an image."""
 
 import asyncio
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor
 import logging
 from pathlib import Path
 import sys
@@ -14,7 +14,6 @@ import cv2
 import numpy as np
 from lxml import etree
 from PIL import Image
-import aiofiles
 
 from utils import (
     PROG,

--- a/papersize.py
+++ b/papersize.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 from typing import Dict, Tuple, Optional
-import numpy as np
 
 from utils import logger
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ lxml>=4.6.0
 Pillow>=8.0.0
 imagehash>=4.2.0
 scikit-image>=0.18.0
-aiofiles>=0.7.0


### PR DESCRIPTION
## Summary
- clean up imports in `ir`
- drop numpy from papersize helper
- remove aiofiles from requirements

## Testing
- `python3 -m py_compile ir papersize.py utils.py analysis.py hashing_config.py`

------
https://chatgpt.com/codex/tasks/task_e_683f3fa1f8ac832892e8911e5260ef38