### PR TITLE
Align defaults for NMS and DPI

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -17,8 +17,8 @@ logger.setLevel(logging.DEBUG)
 PROG = "ir"
 VERSION = "1.3.0"
 
-DEFAULT_NMS_THRESHOLD = 0
-DEFAULT_DPI = 300
+DEFAULT_NMS_THRESHOLD = 0.3
+DEFAULT_DPI = 600
 SUPPORTED_IMAGE_FORMATS = [
     "avif",
     "bmp",


### PR DESCRIPTION
## Summary
- sync the default values for `--nms-threshold` and `--default-dpi` with the documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f3fa3e7c88328a0de2a458bb967a5