### PR TITLE
Add pytest tests for hashing configuration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ lxml>=4.6.0
 Pillow>=8.0.0
 imagehash>=4.2.0
 scikit-image>=0.18.0
+pytest>=8.0.0

--- a/tests/test_hashing_config.py
+++ b/tests/test_hashing_config.py
@@ -1,0 +1,26 @@
+import pytest
+from hashing_config import get_selected_hashes, HASH_CATEGORIES, FEATURE_HASHES
+
+
+def test_basic_preset():
+    assert get_selected_hashes("basic") == HASH_CATEGORIES["basic"]
+
+
+def test_all_preset():
+    assert get_selected_hashes("all") == HASH_CATEGORIES["all"]
+
+
+def test_none_preset():
+    assert get_selected_hashes("none") == set()
+
+
+def test_basic_minus_dhash():
+    result = get_selected_hashes("basic,-dhash")
+    expected = HASH_CATEGORIES["basic"] - {"dhash"}
+    assert result == expected
+
+
+def test_all_minus_feature():
+    result = get_selected_hashes("all,-feature")
+    expected = HASH_CATEGORIES["all"] - FEATURE_HASHES
+    assert result == expected


### PR DESCRIPTION
## Summary
- add a pytest-based test suite for `get_selected_hashes`
- ensure presets (`all`, `none`, `basic`) work
- verify inclusion/exclusion combos like `basic,-dhash` and `all,-feature`
- install pytest via requirements

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684197a2e0f48328bdfbdf48d4c02186