### PR TITLE
Remove unused import

### DIFF
--- a/hashing_config.py
+++ b/hashing_config.py
@@ -2,7 +2,6 @@
 
 import cv2
 import imagehash
-import sys
 from typing import Set, Dict, Callable, Union, List, Optional
 import numpy as np
 from PIL import Image


### PR DESCRIPTION
## Summary
- drop unneeded `sys` import from `hashing_config.py`

## Testing
- `python -m py_compile hashing_config.py`

------
https://chatgpt.com/codex/tasks/task_e_684197a1c0588328841f9bb8abdf65e9