### PR TITLE
Add bounded float argparse type

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ Processing Options:
                         structural, color, other, basic. Prefix with '-' to
                         exclude. (default: basic)
   --nms-threshold NMS_THRESHOLD
-                        Overlap threshold (0.0-1.0) for Non-Maximum Suppression of
-                        bounding boxes. (default: 0.3)
+                        Overlap threshold for Non-Maximum Suppression of
+                        bounding boxes. Must be between 0.0 and 1.0.
+                        (default: 0.3)
   --default-dpi DEFAULT_DPI
                         Assumed DPI for paper size guessing if resolution info is
                         missing. (default: 600)

--- a/analysis.py
+++ b/analysis.py
@@ -17,6 +17,7 @@ def find_bounding_boxes(
     Args:
         image: Input image (BGR format).
         nms_overlap_thresh: IoU threshold for suppressing overlapping boxes.
+            Must be between 0.0 and 1.0.
 
     Returns:
         Numpy array of bounding boxes [[x1, y1, x2, y2], ...], sorted by top-left corner.

--- a/ir
+++ b/ir
@@ -316,7 +316,8 @@ def generate_report_xml(
         input_path: Path to the source image file.
         img_color: Image loaded in BGR format (NumPy array).
         selected_hashes: Set of hash names to compute.
-        nms_threshold: Overlap threshold for bounding box NMS.
+        nms_threshold: Overlap threshold for bounding box NMS. Must be between
+            0.0 and 1.0.
         default_dpi: Assumed DPI for paper size guessing.
 
     Returns:

--- a/tests/test_parse_args.py
+++ b/tests/test_parse_args.py
@@ -1,0 +1,13 @@
+import pytest
+from utils import parse_args
+
+
+def test_nms_threshold_valid():
+    args = parse_args(["input.jpg", "output.xml", "--nms-threshold", "0.5"])
+    assert args.nms_threshold == 0.5
+
+
+def test_nms_threshold_invalid():
+    with pytest.raises(SystemExit):
+        parse_args(["input.jpg", "output.xml", "--nms-threshold", "1.5"])
+

--- a/utils.py
+++ b/utils.py
@@ -43,6 +43,18 @@ SUPPORTED_IMAGE_FORMATS = [
 ]
 
 
+def float_0_1(value: str) -> float:
+    """Argparse type for floats restricted to the [0.0, 1.0] range."""
+    try:
+        fval = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a valid float") from exc
+
+    if 0.0 <= fval <= 1.0:
+        return fval
+    raise argparse.ArgumentTypeError("value must be between 0.0 and 1.0")
+
+
 def setup_logging(
     log_level_stream: int = logging.INFO,
     log_level_file: int = logging.DEBUG,
@@ -100,9 +112,12 @@ def parse_args(args: List[str]) -> argparse.Namespace:
     )
     proc_group.add_argument(
         "--nms-threshold",
-        type=float,
+        type=float_0_1,
         default=DEFAULT_NMS_THRESHOLD,
-        help="Overlap threshold (0.0-1.0) for Non-Maximum Suppression of bounding boxes.",
+        help=(
+            "Overlap threshold for Non-Maximum Suppression of bounding boxes. "
+            "Must be between 0.0 and 1.0."
+        ),
     )
     proc_group.add_argument(
         "--default-dpi",
@@ -204,6 +219,7 @@ def create_element(
 def non_max_suppression(boxes: np.ndarray, overlap_thresh: float) -> np.ndarray:
     """
     Condenses overlapping bounding boxes based on overlap threshold (IoU).
+    ``overlap_thresh`` must be between 0.0 and 1.0.
     Input boxes: numpy array of shape (N, 4) with format [x1, y1, x2, y2].
     Returns: numpy array of shape (M, 4) with suppressed boxes.
     """


### PR DESCRIPTION
## Summary
- validate `--nms-threshold` using new `float_0_1` argparse type
- clarify bounding box threshold parameters in code and docs
- document the valid threshold range in README
- add tests covering argument parsing

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684701f6bec48328a7264091348f8969