### PR TITLE
Add tests for utils.parse_args and analysis functions

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,35 @@
+import numpy as np
+import cv2
+from analysis import find_bounding_boxes, calculate_spectral_analysis
+
+
+def test_find_bounding_boxes_simple_rectangle():
+    img = np.zeros((100, 100, 3), dtype=np.uint8)
+    cv2.rectangle(img, (20, 30), (70, 80), (255, 255, 255), -1)
+    boxes = find_bounding_boxes(img, nms_overlap_thresh=0.1)
+
+    assert boxes.shape[1] == 4
+    assert boxes.shape[0] > 0
+
+
+def test_find_bounding_boxes_empty():
+    boxes = find_bounding_boxes(np.array([]))
+    assert boxes.size == 0
+
+
+def test_calculate_spectral_analysis_simple():
+    img = np.zeros((10, 10, 3), dtype=np.uint8)
+    img[2:5, 3:7] = 255
+    result = calculate_spectral_analysis(img)
+
+    expected_horizontal = [10, 10, 6, 6, 6, 10, 10, 10, 10, 10]
+    expected_vertical = [10, 10, 10, 7, 7, 7, 7, 10, 10, 10]
+
+    assert result is not None
+    assert result["horizontal"] == expected_horizontal
+    assert result["vertical"] == expected_vertical
+
+
+def test_calculate_spectral_analysis_empty():
+    assert calculate_spectral_analysis(None) is None
+    assert calculate_spectral_analysis(np.array([])) is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,37 @@
+import logging
+from pathlib import Path
+from utils import parse_args
+
+
+def test_parse_args_defaults(tmp_path):
+    input_file = tmp_path / "image.jpg"
+    input_file.write_text("data")
+    output_file = tmp_path / "out.xml"
+    args = parse_args([str(input_file), str(output_file)])
+
+    assert args.input_path == input_file
+    assert args.output_path == output_file
+    assert args.log_file == input_file.with_suffix(".ir.log")
+    assert args.log_level_console == "INFO"
+    assert args.log_level_console_int == logging.INFO
+    assert args.log_level_file == "DEBUG"
+    assert args.log_level_file_int == logging.DEBUG
+
+
+def test_parse_args_quiet(tmp_path):
+    input_file = tmp_path / "image.jpg"
+    input_file.write_text("data")
+    output_file = tmp_path / "out.xml"
+    args = parse_args([str(input_file), str(output_file), "--quiet"])
+
+    assert args.log_level_console == "WARNING"
+    assert args.log_level_console_int == logging.WARNING
+
+
+def test_parse_args_directory_input(tmp_path):
+    input_dir = tmp_path / "images"
+    input_dir.mkdir()
+    output_dir = tmp_path / "out"
+    args = parse_args([str(input_dir), str(output_dir)])
+
+    assert args.log_file is None


### PR DESCRIPTION
## Summary
- add `test_utils.py` covering `parse_args` scenarios
- create `test_analysis.py` for `find_bounding_boxes` and `calculate_spectral_analysis`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684701f20c708328998f631149925c7c