### PR TITLE
Handle repeated logging setup

### DIFF
--- a/tests/test_utils_logging.py
+++ b/tests/test_utils_logging.py
@@ -1,0 +1,12 @@
+import logging
+from utils import logger, setup_logging
+
+
+def test_setup_logging_clears_handlers(tmp_path):
+    logger.handlers.clear()
+    log_file = tmp_path / "log.txt"
+    setup_logging(log_file=log_file)
+    first = len(logger.handlers)
+    setup_logging(log_file=log_file)
+    second = len(logger.handlers)
+    assert first == second == 2

--- a/utils.py
+++ b/utils.py
@@ -48,7 +48,15 @@ def setup_logging(
     log_level_file: int = logging.DEBUG,
     log_file: Optional[Union[str, Path]] = None,
 ) -> None:
-    """Initializes logging handlers and format."""
+    """Initializes logging handlers and format.
+
+    Existing handlers are removed so the function can be safely invoked
+    multiple times without duplicating log output.
+    """
+
+    # Remove existing handlers to avoid duplicate logs when called repeatedly
+    if logger.hasHandlers():
+        logger.handlers.clear()
 
     log_format = logging.Formatter("%(asctime)-23s [%(levelname)8s] %(message)s")
 


### PR DESCRIPTION
## Summary
- prevent duplicate log handlers by clearing handlers in `setup_logging`
- explain this behaviour in the docstring
- test that invoking `setup_logging` multiple times doesn't add more handlers

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684701eff43083288b1f93b2c18f6512