### PR TITLE
Use module-level loggers

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -4,7 +4,10 @@ import cv2
 import numpy as np
 from typing import List, Dict, Optional
 
-from utils import logger, non_max_suppression
+import logging
+from utils import non_max_suppression
+
+logger = logging.getLogger(__name__)
 
 
 def find_bounding_boxes(

--- a/hashing_config.py
+++ b/hashing_config.py
@@ -9,7 +9,9 @@ from PIL import Image
 from skimage.morphology import skeletonize
 from skimage.morphology import thin
 
-from utils import logger
+import logging
+
+logger = logging.getLogger(__name__)
 
 ImageType = Union[np.ndarray, Image.Image]
 HashFunctionType = Callable[[ImageType], str]

--- a/ir
+++ b/ir
@@ -19,7 +19,6 @@ from utils import (
     PROG,
     VERSION,
     SUPPORTED_IMAGE_FORMATS,
-    logger,
     setup_logging,
     parse_args,
     create_element,
@@ -35,6 +34,7 @@ from hashing_config import (
 from papersize import STANDARD_SIZES_MM, guess_paper_size, guess_dpi, MM_PER_INCH
 from analysis import find_bounding_boxes, calculate_spectral_analysis
 
+logger = logging.getLogger(__name__)
 
 def _add_metadata(
     parent: etree._Element,

--- a/papersize.py
+++ b/papersize.py
@@ -3,7 +3,9 @@
 from dataclasses import dataclass
 from typing import Dict, Tuple, Optional
 
-from utils import logger
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/tests/test_utils_logging.py
+++ b/tests/test_utils_logging.py
@@ -1,12 +1,15 @@
 import logging
-from utils import logger, setup_logging
+from utils import setup_logging
+
+logger = logging.getLogger(__name__)
 
 
 def test_setup_logging_clears_handlers(tmp_path):
-    logger.handlers.clear()
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
     log_file = tmp_path / "log.txt"
     setup_logging(log_file=log_file)
-    first = len(logger.handlers)
+    first = len(root_logger.handlers)
     setup_logging(log_file=log_file)
-    second = len(logger.handlers)
+    second = len(root_logger.handlers)
     assert first == second == 2

--- a/utils.py
+++ b/utils.py
@@ -66,16 +66,18 @@ def setup_logging(
     multiple times without duplicating log output.
     """
 
-    # Remove existing handlers to avoid duplicate logs when called repeatedly
-    if logger.hasHandlers():
-        logger.handlers.clear()
+    root_logger = logging.getLogger()
+    if root_logger.hasHandlers():
+        root_logger.handlers.clear()
+
+    root_logger.setLevel(logging.DEBUG)
 
     log_format = logging.Formatter("%(asctime)-23s [%(levelname)8s] %(message)s")
 
     stream_handler = logging.StreamHandler(sys.stdout)
     stream_handler.setFormatter(log_format)
     stream_handler.setLevel(log_level_stream)
-    logger.addHandler(stream_handler)
+    root_logger.addHandler(stream_handler)
 
     if log_file:
         log_path = Path(log_file)
@@ -83,7 +85,7 @@ def setup_logging(
         file_handler = logging.FileHandler(log_path, encoding="UTF-8", mode="a")
         file_handler.setFormatter(log_format)
         file_handler.setLevel(log_level_file)
-        logger.addHandler(file_handler)
+        root_logger.addHandler(file_handler)
 
 
 def parse_args(args: List[str]) -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- switch analysis, hashing_config, papersize, and main script to module-level loggers
- configure root logger in setup_logging
- update logging test for new configuration

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893aa6ae1988328bbdc80b3245b6668