### PR TITLE
Fix paper-size confidence unit error

### DIFF
--- a/ir
+++ b/ir
@@ -32,7 +32,13 @@ from hashing_config import (
     CUSTOM_HASH_FUNCTIONS_COLOR,
     ALL_HASHES,
 )
-from papersize import STANDARD_SIZES_MM, guess_paper_size, guess_dpi, MM_PER_INCH
+from papersize import (
+    STANDARD_SIZES_MM,
+    guess_paper_size,
+    guess_dpi,
+    MM_PER_INCH,
+    paper_size_confidence,
+)
 from analysis import find_bounding_boxes, calculate_spectral_analysis
 
 logger = logging.getLogger(__name__)
@@ -65,7 +71,7 @@ def _add_metadata(
     if guesses:
         best_guess_name = next(iter(guesses))
         best_guess_diff = guesses[best_guess_name]
-        confidence = max(0.0, 1.0 - best_guess_diff / (width + height))
+        confidence = paper_size_confidence(best_guess_name, best_guess_diff)
 
         create_element(
             size_elem,
@@ -79,7 +85,7 @@ def _add_metadata(
 
         candidates_elem = create_element(size_elem, "candidates")
         for i, (name, diff) in enumerate(list(guesses.items())[:3]):
-            cand_conf = max(0.0, 1.0 - diff / (width + height))
+            cand_conf = paper_size_confidence(name, diff)
             create_element(
                 candidates_elem,
                 "match",

--- a/papersize.py
+++ b/papersize.py
@@ -126,6 +126,29 @@ def guess_paper_size(pixel_width: int, pixel_height: int, dpi: int) -> Dict[str,
     return dict(sorted_guesses)
 
 
+def paper_size_confidence(paper_type: str, difference_score: float) -> float:
+    """
+    Converts a paper-size difference score into a [0.0, 1.0] confidence.
+
+    ``difference_score`` (as returned by :func:`guess_paper_size`) is the sum of
+    the absolute width and height differences measured in millimetres. To turn
+    it into a scale-free confidence we normalise by the candidate paper's own
+    size (width + height, in mm): a perfect match scores 1.0 and the confidence
+    decays as the mismatch grows relative to the paper's dimensions.
+
+    Returns 0.0 for unknown paper types or degenerate sizes.
+    """
+    standard_size = STANDARD_SIZES_MM.get(paper_type)
+    if standard_size is None:
+        return 0.0
+
+    denominator = standard_size.width_mm + standard_size.height_mm
+    if denominator <= 0:
+        return 0.0
+
+    return max(0.0, 1.0 - difference_score / denominator)
+
+
 def guess_dpi(
     paper_type: str, pixel_width: int, pixel_height: int
 ) -> Tuple[Optional[float], Optional[float]]:

--- a/tests/test_papersize.py
+++ b/tests/test_papersize.py
@@ -1,0 +1,35 @@
+import math
+
+from papersize import (
+    STANDARD_SIZES_MM,
+    guess_paper_size,
+    paper_size_confidence,
+)
+
+
+def test_confidence_is_one_for_perfect_match():
+    assert paper_size_confidence("A4", 0.0) == 1.0
+
+
+def test_confidence_decreases_with_difference():
+    a4 = STANDARD_SIZES_MM["A4"]
+    # A difference of the paper's full (w + h) drives confidence to 0.
+    assert paper_size_confidence("A4", a4.width_mm + a4.height_mm) == 0.0
+    mid = paper_size_confidence("A4", (a4.width_mm + a4.height_mm) / 2.0)
+    assert math.isclose(mid, 0.5, abs_tol=1e-9)
+
+
+def test_confidence_unknown_type_is_zero():
+    assert paper_size_confidence("NotAPaper", 0.0) == 0.0
+
+
+def test_confidence_is_scale_free_across_dpi():
+    # An exact A4 page at any DPI should report full confidence, because the
+    # score is normalized by the paper's mm dimensions rather than by pixels.
+    for dpi in (150, 300, 600):
+        width = round(210 / 25.4 * dpi)
+        height = round(297 / 25.4 * dpi)
+        guesses = guess_paper_size(width, height, dpi)
+        best = next(iter(guesses))
+        assert best == "A4"
+        assert paper_size_confidence(best, guesses[best]) > 0.98


### PR DESCRIPTION
## Problem

The one confidence number the report emits was meaningless. In `_add_metadata` the paper-size confidence was:

```python
confidence = max(0.0, 1.0 - best_guess_diff / (width + height))
```

`best_guess_diff` comes from `guess_paper_size` and is measured in **millimetres** (sum of the width and height differences), while `width + height` is a sum of **pixels**. At 600 dpi the pixel denominator is enormous, so the numerator is negligible and every guess reports confidence ≈ 0.99 regardless of how well it actually fits.

## Fix

Add `papersize.paper_size_confidence(paper_type, difference_score)`, which normalizes the mm difference score by the candidate paper's own dimensions (`width_mm + height_mm`). This is scale-free:

- exact match → `1.0`
- mismatch equal to the paper's full (w + h) → `0.0`
- decays linearly in between

Both call sites (best guess and the candidate list) now use it. An exact A4 page reports full confidence at 150/300/600 dpi, where before the value was dominated by pixel count.

## Tests

Adds `tests/test_papersize.py` covering the perfect-match case, linear decay, unknown paper types, and DPI scale-invariance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMjSFX7t2DMfwbym1DPyMu

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMjSFX7t2DMfwbym1DPyMu)_