### PR TITLE
Clean up vestigial exception handler in fourier_hash

### DIFF
--- a/hashing_config.py
+++ b/hashing_config.py
@@ -156,8 +156,8 @@ def fourier_hash(image: np.ndarray) -> str:
             [format(v, "02x") for v in magnitude_spectrum_uint8.flatten()[:32]]
         )
         return hash_value.ljust(32, "0")
-    except Exception as e:
-        return f"fourier_error"
+    except Exception:
+        return "fourier_error"
 
 
 def skeleton_hash(image: np.ndarray) -> str:


### PR DESCRIPTION
## Problem

`fourier_hash` ended with:

```python
except Exception as e:
    return f"fourier_error"
```

The exception is bound to `e` but never used, and the return is an f-string with no placeholder — both dead artifacts (linters flag them as F841 / F541).

## Fix

```python
except Exception:
    return "fourier_error"
```

No behavioral change; just removes the unused binding and the misleading `f` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMjSFX7t2DMfwbym1DPyMu

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMjSFX7t2DMfwbym1DPyMu)_