### PR TITLE
Deduplicate case-insensitive matches in batch glob

### DIFF
--- a/ir
+++ b/ir
@@ -548,10 +548,15 @@ def main(cli_args: List[str]) -> int:
             output_dir = params.output_path
             output_dir.mkdir(parents=True, exist_ok=True)
 
-            image_paths = []
+            # Deduplicate by resolved path: on case-insensitive filesystems
+            # (macOS, Windows) the lower- and upper-case globs both match the
+            # same file, which would otherwise be processed twice.
+            unique_paths: Dict[Path, Path] = {}
             for fmt in SUPPORTED_IMAGE_FORMATS:
-                image_paths.extend(params.input_path.glob(f"*.{fmt}"))
-                image_paths.extend(params.input_path.glob(f"*.{fmt.upper()}"))
+                for pattern in (f"*.{fmt}", f"*.{fmt.upper()}"):
+                    for path in params.input_path.glob(pattern):
+                        unique_paths.setdefault(path.resolve(), path)
+            image_paths = sorted(unique_paths.values())
 
             if not image_paths:
                 logger.warning(


### PR DESCRIPTION
## Problem

In batch mode the input directory was globbed twice per format — lower-case and upper-case:

```python
for fmt in SUPPORTED_IMAGE_FORMATS:
    image_paths.extend(params.input_path.glob(f"*.{fmt}"))
    image_paths.extend(params.input_path.glob(f"*.{fmt.upper()}"))
```

On case-insensitive filesystems (macOS, Windows) `*.png` and `*.PNG` both match `photo.png`, so every image was processed twice and its report written twice.

## Fix

Collect matches into a dict keyed on `path.resolve()` so each physical file appears once regardless of filesystem case sensitivity, then sort for deterministic ordering:

```python
unique_paths: Dict[Path, Path] = {}
for fmt in SUPPORTED_IMAGE_FORMATS:
    for pattern in (f"*.{fmt}", f"*.{fmt.upper()}"):
        for path in params.input_path.glob(pattern):
            unique_paths.setdefault(path.resolve(), path)
image_paths = sorted(unique_paths.values())
```

Verified in isolation: on a case-sensitive FS `a.png`, `b.PNG`, `c.jpg`, `d.tiff` remain 4 distinct entries; on a case-insensitive FS the resolved-path key collapses the duplicate.

## Note (out of scope)

While smoke-testing batch mode I hit a separate pre-existing crash: `process_batch_async` iterates `asyncio.as_completed(tasks)` and then indexes `tasks[future]`, but `as_completed` yields wrapper coroutines rather than the original `Task` keys, raising `KeyError`. That is addressed in a separate PR that reworks the batch concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMjSFX7t2DMfwbym1DPyMu

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMjSFX7t2DMfwbym1DPyMu)_