### PR TITLE
Encode spectral projections as RLE strings

### DIFF
--- a/ir
+++ b/ir
@@ -23,6 +23,7 @@ from utils import (
     setup_logging,
     parse_args,
     create_element,
+    rle_encode,
 )
 from hashing_config import (
     get_selected_hashes,
@@ -269,30 +270,28 @@ def _add_spectral_analysis(parent: etree._Element, image: np.ndarray) -> None:
 
     if counts:
         counts_elem = create_element(
-            analysis_parent, "spectral_analysis", attrib={"unit": "black_pixel_count"}
+            analysis_parent,
+            "spectral_analysis",
+            attrib={
+                "unit": "black_pixel_count",
+                "encoding": "rle",
+                "rle_format": "space-separated value:run tokens",
+            },
         )
 
-        horiz_elem = create_element(
+        create_element(
             counts_elem,
             "horizontal_projection",
+            text=rle_encode(counts["horizontal"]),
             attrib={"length": str(len(counts["horizontal"]))},
         )
-        for i, count in enumerate(counts["horizontal"]):
-            if count > 0:
-                create_element(
-                    horiz_elem, "row", text=str(count), attrib={"index": str(i)}
-                )
 
-        vert_elem = create_element(
+        create_element(
             counts_elem,
             "vertical_projection",
+            text=rle_encode(counts["vertical"]),
             attrib={"length": str(len(counts["vertical"]))},
         )
-        for i, count in enumerate(counts["vertical"]):
-            if count > 0:
-                create_element(
-                    vert_elem, "column", text=str(count), attrib={"index": str(i)}
-                )
     else:
         create_element(
             analysis_parent,

--- a/tests/test_rle.py
+++ b/tests/test_rle.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from utils import rle_encode, rle_decode
+
+
+def test_encode_basic():
+    assert rle_encode([0, 0, 0, 5, 5, 2]) == "0:3 5:2 2:1"
+
+
+def test_encode_empty():
+    assert rle_encode([]) == ""
+
+
+def test_decode_empty():
+    assert rle_decode("") == []
+    assert rle_decode("   ") == []
+
+
+def test_round_trip_simple():
+    values = [0, 0, 10, 10, 10, 3, 0, 0, 0, 7]
+    assert rle_decode(rle_encode(values)) == values
+
+
+def test_round_trip_random():
+    rng = np.random.default_rng(0)
+    for _ in range(20):
+        # Small alphabet so runs actually occur, like a projection profile.
+        values = rng.integers(0, 4, size=int(rng.integers(0, 200))).tolist()
+        assert rle_decode(rle_encode(values)) == values
+
+
+def test_projection_profile_compresses():
+    # A profile with wide zero margins encodes to far fewer tokens than entries.
+    profile = [0] * 500 + [12, 12, 8] + [0] * 500
+    encoded = rle_encode(profile)
+    assert rle_decode(encoded) == profile
+    assert len(encoded.split()) < len(profile)

--- a/utils.py
+++ b/utils.py
@@ -226,6 +226,47 @@ def create_element(
     return elem
 
 
+def rle_encode(values: List[int]) -> str:
+    """
+    Run-length encode a sequence of integers.
+
+    Returns a space-separated string of ``value:run`` tokens, e.g.
+    ``[0, 0, 0, 5, 5, 2]`` -> ``"0:3 5:2 2:1"``. This losslessly represents a
+    projection profile (including its zero runs) in a couple of short strings
+    instead of one XML element per entry. Returns an empty string for an empty
+    input.
+    """
+    if not values:
+        return ""
+
+    tokens: List[str] = []
+    prev = values[0]
+    run = 1
+    for value in values[1:]:
+        if value == prev:
+            run += 1
+        else:
+            tokens.append(f"{prev}:{run}")
+            prev = value
+            run = 1
+    tokens.append(f"{prev}:{run}")
+    return " ".join(tokens)
+
+
+def rle_decode(encoded: str) -> List[int]:
+    """
+    Decode a string produced by :func:`rle_encode` back into a list of ints.
+
+    Inverse of :func:`rle_encode`; an empty (or whitespace-only) string decodes
+    to an empty list.
+    """
+    values: List[int] = []
+    for token in encoded.split():
+        value_str, _, run_str = token.partition(":")
+        values.extend([int(value_str)] * int(run_str))
+    return values
+
+
 def non_max_suppression(boxes: np.ndarray, overlap_thresh: float) -> np.ndarray:
     """
     Condenses overlapping bounding boxes based on overlap threshold (IoU).


### PR DESCRIPTION
## Problem

The spectral analysis section emitted **one XML element per nonzero row and per nonzero column**:

```xml
<horizontal_projection length="6600">
  <row index="0">12</row>
  <row index="1">15</row>
  ...
</horizontal_projection>
```

A 600-dpi letter page produces on the order of 11,000 `<row>`/`<column>` elements to say what two run-length strings can.

## Fix

Add `rle_encode` / `rle_decode` to `utils.py` (space-separated `value:run` tokens) and serialize each projection profile as a single RLE string:

```xml
<spectral_analysis unit="black_pixel_count" encoding="rle"
                   rle_format="space-separated value:run tokens">
  <horizontal_projection length="10">0:2 4:3 0:5</horizontal_projection>
  <vertical_projection length="10">0:3 3:4 0:3</vertical_projection>
</spectral_analysis>
```

The encoding is lossless **including zero runs**, so a consumer reconstructs the exact profile; margins and inter-line gaps compress well. `analysis.calculate_spectral_analysis` is unchanged — this only affects serialization.

## Verification

- End-to-end: rendered a report, decoded both projection strings with `rle_decode`, and confirmed they equal `calculate_spectral_analysis`'s output exactly. The section now has 2 child elements instead of one-per-nonzero-line.
- New `tests/test_rle.py`: basic encoding, empty cases, random round-trips, and a margin-heavy profile that encodes to far fewer tokens than entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMjSFX7t2DMfwbym1DPyMu

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMjSFX7t2DMfwbym1DPyMu)_